### PR TITLE
test(merge): adding functionality to merge an object set

### DIFF
--- a/src/main/java/uk/gov/dwp/test/LocationRestTestResource.java
+++ b/src/main/java/uk/gov/dwp/test/LocationRestTestResource.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
@@ -124,37 +126,27 @@ public class LocationRestTestResource {
     return String.format(DOWNSTREAM_ALL_USERS_ENDPOINT, configuration.getDownstreamDataSource());
   }
 
-  private List<Integer> calcCityUserIds(List<UserRecordItem> inputItems) {
-    ArrayList<Integer> outList = new ArrayList<>();
-    for (UserRecordItem item : inputItems) {
-      outList.add(item.getId());
-    }
-
-    return outList;
-  }
-
   private List<UserRecordItem> mergeInLocationRecords(
       List<UserRecordItem> inputList, List<UserRecordItem> allUsersList) {
 
-    List<Integer> userListIds = calcCityUserIds(inputList);
-    List<UserRecordItem> outputList = new ArrayList<>(inputList);
-
+    List<UserRecordItem> locationList = new ArrayList<>();
     for (UserRecordItem item : allUsersList) {
 
-      if (!userListIds.contains(item.getId())
-          && DistanceCalculator.distanceWithinAllowableRadius(
+      if (DistanceCalculator.distanceWithinAllowableRadius(
               ServiceConstants.LONDON_LAT,
               ServiceConstants.LONDON_LNG,
               item.getLatitude(),
               item.getLongitude(),
               configuration.getCityRadius())) {
 
-        userListIds.add(item.getId());
-        outputList.add(item);
+        locationList.add(item);
       }
     }
 
-    return outputList;
+    Set<UserRecordItem> mergedSet = new HashSet<>(inputList);
+    mergedSet.addAll(locationList);
+
+    return new ArrayList<>(mergedSet);
   }
 
   private String serialiseForOutput(List<UserRecordItem> fullListItem)

--- a/src/main/java/uk/gov/dwp/test/application/items/UserRecordItem.java
+++ b/src/main/java/uk/gov/dwp/test/application/items/UserRecordItem.java
@@ -1,8 +1,10 @@
 package uk.gov.dwp.test.application.items;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import java.util.Objects;
 import javax.validation.constraints.NotNull;
 import uk.gov.dwp.test.application.items.ViewItems.RedactedUserReturn;
 
@@ -92,5 +94,21 @@ public class UserRecordItem implements AbstractItem {
 
   public void setLongitude(double longitude) {
     this.longitude = longitude;
+  }
+
+  @Override
+  @JsonIgnore
+  public int hashCode() {
+    return Objects.hash(this.getId(), this.getFirstName(), this.getLastName());
+  }
+
+  @Override
+  @JsonIgnore
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    return this.getId() == ((UserRecordItem) o).getId();
   }
 }


### PR DESCRIPTION
changes required to enable a Set to be merged without duplicates.  this involved overriding the standard 'equals' and 'hashcode' methods of the object in order to correctly allow the same content to be evaluated in the `addAll` method.

The functionality to examine each of the "all users" return list is still required because of the need to calculate the distance before adding to the output list.

Just wondering if this is more or less efficient that creating a list of the (unique) ids, testing and marking them off as items are added.  Is there a more concise way to perform the `mergeInLocationRecords` method?